### PR TITLE
Feat/login kakao

### DIFF
--- a/src/main/java/com/sbackjung/transferstay/config/SecurityConfig.java
+++ b/src/main/java/com/sbackjung/transferstay/config/SecurityConfig.java
@@ -1,0 +1,2 @@
+package com.sbackjung.transferstay.config;public class SecurityConfig {
+}

--- a/src/main/java/com/sbackjung/transferstay/controller/OAuth2TestController.java
+++ b/src/main/java/com/sbackjung/transferstay/controller/OAuth2TestController.java
@@ -1,0 +1,12 @@
+package com.sbackjung.transferstay.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class OAuth2TestController {
+  @GetMapping("/auth/success")
+  public String home() {
+    return "success";
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/domain/Auditable.java
+++ b/src/main/java/com/sbackjung/transferstay/domain/Auditable.java
@@ -1,0 +1,2 @@
+package com.sbackjung.transferstay.domain;public class Auditable {
+}

--- a/src/main/java/com/sbackjung/transferstay/domain/Role.java
+++ b/src/main/java/com/sbackjung/transferstay/domain/Role.java
@@ -1,0 +1,6 @@
+package com.sbackjung.transferstay.domain;
+
+public enum Role {
+  USER,
+  ADMIN
+}

--- a/src/main/java/com/sbackjung/transferstay/domain/SocialType.java
+++ b/src/main/java/com/sbackjung/transferstay/domain/SocialType.java
@@ -1,0 +1,6 @@
+package com.sbackjung.transferstay.domain;
+
+public enum SocialType {
+  NAVER,
+  KAKAO
+}

--- a/src/main/java/com/sbackjung/transferstay/domain/User.java
+++ b/src/main/java/com/sbackjung/transferstay/domain/User.java
@@ -1,0 +1,38 @@
+package com.sbackjung.transferstay.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "users")
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_Id")
+  private Long id;
+
+  private String email;
+  private String password;
+  private String name;
+  private String phone;
+  private String nickname;
+
+  private String socialId;
+
+  @Enumerated(EnumType.STRING)
+  private Role role;
+
+  @Enumerated(EnumType.STRING)
+  private SocialType socialType;
+
+  private String refreshToken;
+
+}

--- a/src/main/java/com/sbackjung/transferstay/jwt/JwtUtils.java
+++ b/src/main/java/com/sbackjung/transferstay/jwt/JwtUtils.java
@@ -1,0 +1,44 @@
+package com.sbackjung.transferstay.jwt;
+
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtils {
+
+  @Value("${jwt.secret}")
+  private String jwtSecret;
+
+  @Value("${jwt.token-validity-in-seconds}")
+  private long tokenValidityInSeconds;
+
+  public String generateToken(String email, String role) {
+    Date now = new Date();
+    Date expiryDate = new Date(now.getTime() + tokenValidityInSeconds * 1000);
+
+    return Jwts.builder()
+        .setSubject(email)
+        .claim("role", role)
+        .setIssuedAt(now)
+        .setExpiration(expiryDate)
+        .signWith(SignatureAlgorithm.HS512, jwtSecret)
+        .compact();
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public String getEmailFromToken(String token) {
+    Claims claims = Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token).getBody();
+    return claims.getSubject();
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/oauth2/PrincipalDetails.java
+++ b/src/main/java/com/sbackjung/transferstay/oauth2/PrincipalDetails.java
@@ -1,0 +1,53 @@
+package com.sbackjung.transferstay.oauth2;
+
+import com.sbackjung.transferstay.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+// 추후 자체 회원가입 구현을 위해 PrincipalDetails 을 구현하였음
+@Getter
+public class PrincipalDetails implements UserDetails, OAuth2User {
+
+  private final User user;
+  private Map<String, Object> attributes;
+
+  public PrincipalDetails(User user){
+    this.user = user;
+  }
+
+  public PrincipalDetails(User user, Map<String, Object> attributes) {
+    this.user = user;
+    this.attributes = attributes;
+  }
+
+  @Override
+  public String getName() {
+    return user.getEmail();
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return Map.of();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(() -> "ROLE_" + user.getRole().name());
+  }
+
+  @Override
+  public String getPassword() {
+    return "";
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getEmail();
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/sbackjung/transferstay/oauth2/handler/OAuth2FailureHandler.java
@@ -1,0 +1,19 @@
+package com.sbackjung.transferstay.oauth2.handler;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
+    response.sendRedirect("/login?error=" + exception.getMessage());
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/sbackjung/transferstay/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,41 @@
+package com.sbackjung.transferstay.oauth2.handler;
+
+import com.sbackjung.transferstay.domain.User;
+import com.sbackjung.transferstay.jwt.JwtUtils;
+import com.sbackjung.transferstay.oauth2.PrincipalDetails;
+import com.sbackjung.transferstay.repository.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+  private final JwtUtils jwtUtils;
+  private final UserRepository userRepository;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+    OAuth2AuthenticationToken oAuth2Token = (OAuth2AuthenticationToken) authentication;
+    PrincipalDetails principalDetails = (PrincipalDetails) oAuth2Token.getPrincipal();
+
+    // 사용자 정보로 JWT 토큰 생성
+    User user = principalDetails.getUser();
+    String jwtToken = jwtUtils.generateToken(user.getEmail(), user.getRole().name());
+
+    // JWT 토큰을 헤더에 추가
+    response.addHeader("Authorization", "Bearer " + jwtToken);
+
+    // 기본 성공 URL로 리다이렉트
+    response.sendRedirect("http://localhost:8080/auth/success");
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/oauth2/service/PrincipalOauthUserService.java
+++ b/src/main/java/com/sbackjung/transferstay/oauth2/service/PrincipalOauthUserService.java
@@ -1,0 +1,60 @@
+package com.sbackjung.transferstay.oauth2.service;
+
+import com.sbackjung.transferstay.domain.Role;
+import com.sbackjung.transferstay.domain.SocialType;
+import com.sbackjung.transferstay.domain.User;
+import com.sbackjung.transferstay.oauth2.PrincipalDetails;
+import com.sbackjung.transferstay.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalOauthUserService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthorizationException {
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+
+    Map<String, Object> properties = oAuth2User.getAttribute("properties");
+    Map<String, Object> account = oAuth2User.getAttribute("kakao_account");
+
+    String providerId = oAuth2User.getAttribute("id").toString();
+
+    String email = (String) account.get("email");
+    String name = (String) account.get("name");
+    String phone = (String) account.get("phone_number");
+    String nickname = (String) account.get("profile_nickname");
+
+    Optional<User> optionalUser = userRepository.findByEmail(email);
+    User user;
+
+    // 카카오 네이버 별로 dto 만들예정
+    if (optionalUser.isEmpty()) {
+      user = User.builder()
+          .email(email)
+          .name(name)
+          .phone(phone)
+          .nickname(nickname)
+          .role(Role.USER)
+          .socialId(providerId)
+          .socialType(SocialType.KAKAO) // 추후 수정 ( 구현된 소셜이 kakao 하나다 보니 직접 적음)
+          .build();
+
+      userRepository.save(user);
+    } else {
+      user = optionalUser.get();
+    }
+
+    return new PrincipalDetails(user, oAuth2User.getAttributes());
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/oauth2/service/PrincipalService.java
+++ b/src/main/java/com/sbackjung/transferstay/oauth2/service/PrincipalService.java
@@ -1,0 +1,31 @@
+package com.sbackjung.transferstay.oauth2.service;
+
+import com.sbackjung.transferstay.domain.User;
+import com.sbackjung.transferstay.oauth2.PrincipalDetails;
+import com.sbackjung.transferstay.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * 자체 로그인 전용 CustomUserDetailService
+ */
+@Service
+@RequiredArgsConstructor
+public class PrincipalService implements UserDetailsService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    Optional<User> findUser = userRepository.findByEmail(email);
+
+    // 사용자 존재 여부 확인
+    return findUser.map(PrincipalDetails::new)
+        .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
+  }
+}

--- a/src/main/java/com/sbackjung/transferstay/repository/UserRepository.java
+++ b/src/main/java/com/sbackjung/transferstay/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.sbackjung.transferstay.repository;
+
+import com.sbackjung.transferstay.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}


### PR DESCRIPTION
### 개요

카카오 소셜 로그인 기능을 구현했습니다.

<br>

**관련 issue**
- #4 
<br>

### Feat

- 사용자가 카카오에 로그인시 로그인한 사용자의 정보를 받게되며 , 사용자의 이메일을 통해 가입여부를 판단한뒤 가입이 안되있다면 사용자의 정보를 저장하고 가입이 되어있다면 jwt토큰을 발행합니다.

- 에러처리 , 테스트코드 구현이 필요합니다. 

### Test Result
![카카오 로그인창](https://github.com/user-attachments/assets/8e46503e-6d00-41f0-a58e-4cd27508aa63)
![카카오 로그인 후](https://github.com/user-attachments/assets/487034aa-81d0-4bdb-b1b9-79eace775f46)
![db](https://github.com/user-attachments/assets/e440ab64-7997-4949-aa40-58fa52d75567)


### To Reviewer
- redirect url 수정이 필요합니다.
